### PR TITLE
Upgrade selectors in `lemon/index.less` for Atom v1.13.0.

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -49,66 +49,66 @@
   opacity: 0.7;
 }
 
-.comment {
+.syntax--comment {
   color: @base01;
   font-style: italic;
 }
 
-.entity {
+.syntax--entity {
   color: @green;
 }
 
-.keyword {
+.syntax--keyword {
   color: @yellow;
   font-weight: 600;
 }
 
-.storage.type {
+.syntax--storage.syntax--type {
   color: @green;
 }
 
-.constant {
+.syntax--constant {
   color: @teal;
 
-  &.numeric,
-  &.boolean {
+  &.syntax--numeric,
+  &.syntax--boolean {
     color: @teal;
   }
 }
 
-.variable {
+.syntax--variable {
   color: @blue;
 }
 
-.delimiter, .brace {
+.syntax--delimiter, .syntax--brace {
   color: @cyan;
 }
 
-.delimiter.period {
+.syntax--delimiter.syntax--period {
   color: @green;
 }
 
-.invalid.deprecated {
+.syntax--invalid.syntax--deprecated {
   text-decoration: underline;
   color: @red;
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
   color: @red;
 }
 
-.string {
+.syntax--string {
   color: @teal;
 
-  .constant.character.escape {
+  .syntax--constant.syntax--character.syntax--escape {
     color: @red;
   }
 
-  &.regexp {
+  &.syntax--regexp {
     color: @cyan;
 
-    .source.ruby.embedded,
-    .string.regexp.arbitrary-repitition {
+    .syntax--source.syntax--ruby.syntax--embedded,
+    .syntax--string.syntax--regexp.syntax--arbitrary-repitition {
       color: @red;
     }
   }


### PR DESCRIPTION
Warning: untested. (Intend to circle back and test, but figured worth offering changeset soonest to help address the deprecation.)

Here's the "Deprecation Cop" message I was working from:

```Markdown
In `lemon/index.less`: 

Starting from Atom v1.13.0, the contents of `atom-text-editor` elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using `:host` and `::shadow` pseudo-selectors, and prepend all your syntax selectors with `syntax--`. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:

* `.comment` => `.syntax--comment`

* `.entity` => `.syntax--entity`

* `.keyword` => `.syntax--keyword`

* `.storage.type` => `.syntax--storage.syntax--type`

* `.constant` => `.syntax--constant`

* `.constant.numeric,
.constant.boolean` => `.syntax--constant.syntax--numeric,
.syntax--constant.syntax--boolean`

* `.variable` => `.syntax--variable`

* `.delimiter,
.brace` => `.syntax--delimiter,
.syntax--brace`

* `.delimiter.period` => `.syntax--delimiter.syntax--period`

* `.invalid.deprecated` => `.syntax--invalid.syntax--deprecated`

* `.invalid.illegal` => `.syntax--invalid.syntax--illegal`

* `.string` => `.syntax--string`

* `.string .constant.character.escape` => `.syntax--string .syntax--constant.syntax--character.syntax--escape`

* `.string.regexp` => `.syntax--string.syntax--regexp`

* `.string.regexp .source.ruby.embedded,
.string.regexp .string.regexp.arbitrary-repitition` => `.syntax--string.syntax--regexp .syntax--source.syntax--ruby.syntax--embedded,
.syntax--string.syntax--regexp .syntax--string.syntax--regexp.syntax--arbitrary-repitition`

Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible.
```